### PR TITLE
/wiki/index/가 404 status로 응답하는 문제를 고쳐라

### DIFF
--- a/_wiki/index.md
+++ b/_wiki/index.md
@@ -1,3 +1,12 @@
+---
+layout  : wikiindex
+title   : wiki
+toc     : true
+public  : true
+comment : false
+regenerate: true
+---
+
 * TOC
 {:toc
 


### PR DESCRIPTION
* 문제의 마크다운 파일의 메타데이터를 추가하였습니다.